### PR TITLE
transmission: fix label to match string id

### DIFF
--- a/addons/service/downloadmanager/transmission/source/resources/settings.xml
+++ b/addons/service/downloadmanager/transmission/source/resources/settings.xml
@@ -16,7 +16,7 @@
 		<setting type="sep" />
 		<setting label="3110" type="lsep"/>
 		<setting id="TRANSMISSION_DL_DIR" type="folder" label="3121" value="" default="/storage/downloads" />
-		<setting id="TRANSMISSION_INC_DIR" type="folder" label="3122" value="" default="/storage/downloads/incoming" />
-		<setting id="TRANSMISSION_WATCH_DIR" type="folder" label="3123" value="" default="/storage/downloads/watch" />
+		<setting id="TRANSMISSION_WATCH_DIR" type="folder" label="3122" value="" default="/storage/downloads/watch" />
+		<setting id="TRANSMISSION_INC_DIR" type="folder" label="3123" value="" default="/storage/downloads/incoming" />
     </category>
 </settings>


### PR DESCRIPTION
Switched 3122/3123 labels to match IDs of English and Dutch translations.
