### PR TITLE
Change service type of transmission to idle

### DIFF
--- a/addons/service/downloadmanager/transmission/source/system.d/service.downloadmanager.transmission.service
+++ b/addons/service/downloadmanager/transmission/source/system.d/service.downloadmanager.transmission.service
@@ -3,6 +3,7 @@ Description=Transmission BT Client
 After=graphical.target
 
 [Service]
+Type=idle
 ExecStart=/bin/sh -c "exec sh /storage/.kodi/addons/service.downloadmanager.transmission/bin/transmission.start"
 TimeoutStopSec=1
 Restart=always


### PR DESCRIPTION
Since Openelec 4.2 transmission-daemon is started before any drive handle by automount ismounted.

This means, that if the working folders (download, watch, incoming) of transmission live on one of these external devices (this is the normal case for instance of a raspberry Pi system), transmission-daemon can't find them: when checked at the web interface all torrent are broken (no data found).

If the transmission daemon is killed, that after systemd automatically restart it, all the torrent are OK but in pause.

I play a lot using the After/Before keys, but I get success only changing service type to idle. From systemd(5):

           Behavior of idle is very similar to simple; however, actual
           execution of the service binary is delayed until all jobs are
           dispatched. This may be used to avoid interleaving of output of
           shell services with the status output on the console.