### PR TITLE
socat: build for all projects

### DIFF
--- a/addons/tools/socat/package.mk
+++ b/addons/tools/socat/package.mk
@@ -20,8 +20,8 @@
 
 PKG_NAME="socat"
 PKG_VERSION="1.7.2.4"
-PKG_REV="2"
-PKG_ARCH="x86_64"
+PKG_REV="3"
+PKG_ARCH="any"
 PKG_LICENSE="GPL2"
 PKG_SITE="http://www.dest-unreach.org/socat/"
 PKG_URL="http://www.dest-unreach.org/socat/download/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Hi,

socat is useful for sending xmltv.xml to xmltv.sock of tvheadend.
I confirmed this builds fine for both imx6 and RPi and tested on both architectures.