### PR TITLE
rTorrent: version bumped to 4.3.3

### DIFF
--- a/addons/service/downloadmanager/rTorrent/changelog.txt
+++ b/addons/service/downloadmanager/rTorrent/changelog.txt
@@ -1,3 +1,9 @@
+4.3.3
+- enable fist segment loading for *.avi,*.mp4,*.mkv files. makes them play at once.
+- added better logging.
+- moved to systemd service.
+- removed ARM optimizations. ARMs are strong now.
+
 4.3.2
 - update to kodi
 

--- a/addons/service/downloadmanager/rTorrent/package.mk
+++ b/addons/service/downloadmanager/rTorrent/package.mk
@@ -20,7 +20,7 @@
 
 PKG_NAME="rTorrent"
 PKG_VERSION="4.3"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libtorrent.rakshasa.no"
@@ -37,7 +37,7 @@ PKG_ADDON_REQUIRES="tools.php:0.0.0 tools.dtach:0.0.0"
 
 PKG_AUTORECONF="no"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"
 
 make_target() {
   : # nop
@@ -60,6 +60,4 @@ addon() {
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/rutorrent/
   cp -r $(get_build_dir rutorrent)/* $ADDON_BUILD/$PKG_ADDON_ID/rutorrent/
-
-  cp $PKG_DIR/extra/rtorrent.default.rc $ADDON_BUILD/$PKG_ADDON_ID/rtorrent.default.rc
 }

--- a/addons/service/downloadmanager/rTorrent/source/bin/php.ini
+++ b/addons/service/downloadmanager/rTorrent/source/bin/php.ini
@@ -1,2 +1,3 @@
 cgi.force_redirect = 0
-cgi.redirect_status_env = "yes";
+cgi.redirect_status_env = yes
+date.timezone = UTC

--- a/addons/service/downloadmanager/rTorrent/source/bin/rtorrent.start
+++ b/addons/service/downloadmanager/rTorrent/source/bin/rtorrent.start
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
 #      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
@@ -27,9 +26,7 @@
 
 . /etc/profile
 
-ADDON_DIR="$HOME/.kodi/addons/service.downloadmanager.rTorrent"
-ADDON_HOME="$HOME/.kodi/userdata/addon_data/service.downloadmanager.rTorrent"
-ADDON_SETTINGS="$ADDON_HOME/settings.xml"
+oe_setup_addon service.downloadmanager.rTorrent
 
 RTORRENT_RC="$ADDON_HOME/rtorrent.rc"
 RTORRENT_SESSION="$ADDON_HOME/session"
@@ -40,11 +37,8 @@ RTORRENT_ARG="-n -o import=$RTORRENT_RC -s $RTORRENT_SESSION"
 RUTORRENT_CONF="$ADDON_DIR/rutorrent-httpd.conf"
 RUTORRENT_CONF_DIR="$ADDON_HOME/rutorrent"
 
-LOCKDIR="/var/lock/"
-LOCKFILE="rtorrent.disabled"
-LOG_FILE="$ADDON_HOME/service.log"
+LOG_FILE="$ADDON_HOME/rtorrent.log"
 
-[ -d $ADDON_HOME ] || mkdir -p $ADDON_HOME
 [ -d $RTORRENT_SESSION ] || mkdir -p $RTORRENT_SESSION
 [ -d $RUTORRENT_CONF_DIR ] || mkdir -p $RUTORRENT_CONF_DIR
 [ -d $RUTORRENT_CONF_DIR/torrents ] || mkdir -p $RUTORRENT_CONF_DIR/torrents
@@ -57,35 +51,18 @@ if [ -f $ADDON_DIR/firstrun ];then
 	[ -f "$RTORRENT_RC" ] && mv "$RTORRENT_RC" "$RTORRENT_RC.old"
 fi
 
-if [ ! -f "$ADDON_SETTINGS" ]; then
-  cp $ADDON_DIR/settings-default.xml $ADDON_SETTINGS
-fi
-
-uname -m |grep -q -i arm
-if [ $? -eq 0 ];then
-  grep -q -i "RPi ARM" $ADDON_DIR/rtorrent.default.rc
-  [ $? -gt 0 ] && echo "# RPi ARM Tunning
-max_peers = 10
-max_uploads_global = 5
-max_downloads_global = 5
-max_memory_usage = 128M" >> $ADDON_DIR/rtorrent.default.rc
-fi
-
-if [ ! -f "$RTORRENT_RC" ]; then
+if [ ! -f "$RTORRENT_RC" ];then
   cp $ADDON_DIR/rtorrent.default.rc $RTORRENT_RC
 fi
 
-[ -d /var/config ] || mkdir -p /var/config
-cat "$ADDON_SETTINGS" | awk -F\" '{print $2"=\""$4"\""}' | sed '/^=/d' > /var/config/rtorrent.conf
-
-. /var/config/rtorrent.conf
-
-# Please dont auto start on install
-if [ "$RTORRENT_ENABLED" == "false" ];then
-	exit 0
-fi
-
 RTORRENT_ARG="$RTORRENT_ARG -p $RTORRENT_PORTS -o download_rate=$RTORRENT_DOWN_RATE -o upload_rate=$RTORRENT_UP_RATE"
+
+# Logging
+if [ "$DEBUG" == "yes" ];then
+	RTORRENT_ARG="$RTORRENT_ARG -O log.open_file=\"rtorrent\","$LOG_FILE" -O log.add_output=\"debug\",\"rtorrent\""
+else
+	RTORRENT_ARG="$RTORRENT_ARG -O log.open_file=\"rtorrent\","$LOG_FILE" -O log.add_output=\"info\",\"rtorrent\""
+fi
 
 # Check upnp support if upnp enabled.
 if [ "$RTORRENT_UPNP" == "true" -o "$RUTORRENT_UPNP" == "true" -a "$RUTORRENT_AUTH" == "true" ];then
@@ -134,36 +111,24 @@ if [ "$RTORRENT_UPDATE_ON_COMPLETE" == "true" ];then
 	RTORRENT_ARG="$RTORRENT_ARG -O system.method.set_key=event.download.finished,update_on_complete,\"execute=xbmc-libup.sh\""
 fi
 
-if [ ! "$(pidof rtorrent)" ];then
-  [ -f "$LOCKDIR/$LOCKFILE" ] && rm -f "$LOCKDIR/$LOCKFILE"
-  while [ true ] ; do
-    # FIX: Broken addon uninstaller does not stop the addon
-    if [ ! -d "$ADDON_DIR/bin" ];then
-        killall rtorrent
-        if [ "$RUTORRENT_ENABLED" == "true" ];then
-           RUTORRENT_PID=$(ps |grep "http[d] -p $RUTORRENT_PORT"|awk '{print $1}')
-           kill $RUTORRENT_PID
-        fi
-        break
-    fi
-    if [ -f "$LOCKDIR/$LOCKFILE" ] ; then
-      break
-    fi 
-    
-    # Start
-    if [ ! "$(pidof rtorrent)" ];then
-        [ -f $RTORRENT_LOCKFILE ] && rm -f $RTORRENT_LOCKFILE
-        dtach -n $RTORRENT_DTACH_FILE rtorrent $RTORRENT_ARG &>$LOG_FILE
-    fi
-    if [ ! "$(ps |grep "http[d] -p $RUTORRENT_PORT")" ];then
-	if [ "$RUTORRENT_ENABLED" == "true" ];then
-		httpd -p $RUTORRENT_PORT -c $RUTORRENT_CONF >>$LOG_FILE
-		# Start plugins
-		$ADDON_DIR/bin/php -c $ADDON_DIR/bin/php.ini $ADDON_DIR/rutorrent/php/initplugins.php >>$LOG_FILE
+while [ true ];do
+	# Start
+	if [ ! "$(pidof rtorrent)" ];then
+		[ -f $RTORRENT_LOCKFILE ] && rm -f $RTORRENT_LOCKFILE
+		dtach -n $RTORRENT_DTACH_FILE rtorrent $RTORRENT_ARG
+		echo "Started rTorrent: $?"
 	fi
-    fi
-    sleep 1 
-  done &
-fi
+	if [ ! "$(ps |grep "http[d] -p $RUTORRENT_PORT")" ];then
+		if [ "$RUTORRENT_ENABLED" == "true" ];then
+			httpd -p $RUTORRENT_PORT -c $RUTORRENT_CONF
+			echo "Started ruTorrent: $?"
+			# Start plugins
+			sleep 10
+			$ADDON_DIR/bin/php -c $ADDON_DIR/bin/php.ini $ADDON_DIR/rutorrent/php/initplugins.php
+			echo "Started ruTorrent plugins: $?"
+		fi
+	fi
+	sleep 1
+done &
 
 # vim:ts=4:sw=4

--- a/addons/service/downloadmanager/rTorrent/source/default.py
+++ b/addons/service/downloadmanager/rTorrent/source/default.py
@@ -17,25 +17,3 @@
 #  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
 #  http://www.gnu.org/copyleft/gpl.html
 ################################################################################
-
-import os, xbmcaddon, xbmc, subprocess
-from time import sleep
-
-__scriptname__ = "rTorrent - Torrent Client"
-__author__     = "Jenkinz"
-__url__        = "http://www.openelec.tv"
-__settings__   = xbmcaddon.Addon()
-__cwd__        = __settings__.getAddonInfo('path')
-__start__      = xbmc.translatePath( os.path.join( __cwd__, 'bin', "rtorrent.start") )
-__stop__       = xbmc.translatePath( os.path.join( __cwd__, 'bin', "rtorrent.stop") )
-
-#make binary files executable in addon bin folder
-subprocess.Popen("chmod -R +x " + __cwd__ + "/bin/*" , shell=True, close_fds=True)
-
-subprocess.Popen(__start__, shell=True, close_fds=True)
-
-while (not xbmc.abortRequested):
-    sleep(0.500)
-
-subprocess.Popen(__stop__, shell=True, close_fds=True)
-

--- a/addons/service/downloadmanager/rTorrent/source/resources/language/English/strings.xml
+++ b/addons/service/downloadmanager/rTorrent/source/resources/language/English/strings.xml
@@ -4,7 +4,6 @@
 	<!-- rTorrent -->
 	<string id="1000">rTorrent Service</string>
 	<string id="1001">rTorrent Service Settings</string>
-	<string id="1002">Enable Service:</string>
 	<string id="1003">Port Range:</string>
 	<string id="1004">Download Rate (kb/s):</string>
 	<string id="1005">Upload Rate (kb/s):</string>

--- a/addons/service/downloadmanager/rTorrent/source/resources/settings.xml
+++ b/addons/service/downloadmanager/rTorrent/source/resources/settings.xml
@@ -5,12 +5,11 @@
     <category label="1000">
 		<setting label="1001" type="lsep"/>
 		<setting type="sep" />
-		<setting id="RTORRENT_ENABLED" type="bool" label="1002" default="false"/>
-		<setting id="RTORRENT_PORTS" type="text" label="1003" enable="eq(-1,true)" default="6895-6895"/>
-		<setting id="RTORRENT_UPNP" type="bool" label="1006" enable="eq(-2,true)" default="false"/>
-		<setting id="RTORRENT_DOWN_RATE" type="text" label="1004" enable="eq(-3,true)" default="1024"/>
-		<setting id="RTORRENT_UP_RATE" type="text" label="1005" enable="eq(-4,true)" default="50"/>
-		<setting id="RTORRENT_UPDATE_ON_COMPLETE" type="bool" label="1007" enable="eq(-5,true)" default="false"/>
+		<setting id="RTORRENT_PORTS" type="text" label="1003" default="6895-6895"/>
+		<setting id="RTORRENT_UPNP" type="bool" label="1006" default="false"/>
+		<setting id="RTORRENT_DOWN_RATE" type="text" label="1004" default="1024"/>
+		<setting id="RTORRENT_UP_RATE" type="text" label="1005" default="50"/>
+		<setting id="RTORRENT_UPDATE_ON_COMPLETE" type="bool" label="1007" default="false"/>
     </category>
     
     <!-- rTorrent Watch Settings -->

--- a/addons/service/downloadmanager/rTorrent/source/rtorrent.default.rc
+++ b/addons/service/downloadmanager/rTorrent/source/rtorrent.default.rc
@@ -3,6 +3,13 @@
 # Seting useful umask
 system.umask.set=0002
 
+# Enable File Prioritize feature
+file.prioritize_toc.set=1
+
+# List of files it is applied to (assuming the above is set), applied to first
+# and last chunk repectively. The matching is done when a download is inserted.
+file.prioritize_toc.first.set = {*.avi,*.mp4,*.mkv}
+
 # This will set rtorrent/scgi to listen on localhost, port 5000.
 scgi_port = localhost:5000
 

--- a/addons/service/downloadmanager/rTorrent/source/system.d/service.downloadmanager.rTorrent.service
+++ b/addons/service/downloadmanager/rTorrent/source/system.d/service.downloadmanager.rTorrent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=rTorrent Service
+After=graphical.target
+
+[Service]
+Type=forking
+ExecStart=/bin/sh -c "exec sh /storage/.kodi/addons/service.downloadmanager.rTorrent/bin/rtorrent.start"
+TimeoutStopSec=2
+Restart=always
+RestartSec=2
+StartLimitInterval=0
+
+[Install]
+WantedBy=kodi.target

--- a/addons/tools/dtach/package.mk
+++ b/addons/tools/dtach/package.mk
@@ -36,7 +36,7 @@ PKG_ADDON_TYPE="xbmc.python.script"
 
 PKG_AUTORECONF="no"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"
 
 PKG_DISCLAIMER="this is an unofficial addon. please don't ask for support in openelec forum / irc channel"
 

--- a/download/rtorrent/package.mk
+++ b/download/rtorrent/package.mk
@@ -33,7 +33,7 @@ PKG_LONGDESC="rTorrent bittorrent client can handel multipel watch dirs and post
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"
 
 PKG_CONFIGURE_OPTS_TARGET="ax_cv_header_ncurses_curses_h=yes --disable-debug \
             --with-xmlrpc-c=$SYSROOT_PREFIX/usr/bin/xmlrpc-c-config \

--- a/lib/libtorrent/package.mk
+++ b/lib/libtorrent/package.mk
@@ -33,7 +33,7 @@ PKG_IS_ADDON="no"
 
 PKG_AUTORECONF="yes"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
             --enable-static \

--- a/lib/xmlrpc-c/package.mk
+++ b/lib/xmlrpc-c/package.mk
@@ -33,7 +33,7 @@ PKG_IS_ADDON="no"
 
 PKG_AUTORECONF="no"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-libxml2-backend \
             --disable-nls \

--- a/net/miniupnpc/package.mk
+++ b/net/miniupnpc/package.mk
@@ -33,7 +33,7 @@ PKG_LONGDESC=""
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"
 
 make_target() {
   cd $ROOT/$PKG_BUILD

--- a/system/cppunit/package.mk
+++ b/system/cppunit/package.mk
@@ -33,4 +33,4 @@ PKG_LONGDESC=""
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"

--- a/web/rutorrent/package.mk
+++ b/web/rutorrent/package.mk
@@ -35,7 +35,7 @@ PKG_IS_ADDON="no"
 
 PKG_AUTORECONF="no"
 
-PKG_MAINTAINER="Daniel Forsberg (daniel.forsberg1@gmail.com)"
+PKG_MAINTAINER="Daniel Forsberg (jenkins101)"
 
 pre_patch() {
   chmod -R +w $ROOT/$BUILD/${PKG_NAME}-${PKG_VERSION}/*


### PR DESCRIPTION
 enable fist segment loading for *.avi,*.mp4,*.mkv files. makes them play at once.
 added date.timezone = UTC to php.ini to make php stop complaining about it.
 added better logging and systemd compatibility.
 move rtorrent.default.rc back to default location.
 removed default ARM optimizations ARMs are strong now.