### PR TITLE
Update libmtp to 1.1.8

### DIFF
--- a/lib/libmtp/package.mk
+++ b/lib/libmtp/package.mk
@@ -19,8 +19,8 @@
 ################################################################################
 
 PKG_NAME="libmtp"
-PKG_VERSION="1.1.6"
-PKG_REV="1"
+PKG_VERSION="1.1.8"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libmtp.sourceforge.net/"


### PR DESCRIPTION
Changes from 1.1.7 to 1.1.8:
- Fix builds on systems with strndup in the C library.  Nothing else.

Changes from 1.1.6 to 1.1.7:
- Soname libmtp.so.9.2.0 - binary compatible, new interfaces
  have been added.
- Compilation fixes for older GCC and non-GCC compilers.
- Finalize >4GB file transfer changes so this works now.
- A new API to check for device capabilities has been added.
- Sync in latest upstream ptp2 changes.
- Support for USB 3.0! (A patch adding async buffering was
 reverted after deemed instable by Debian.)
- Some migration toward the new API in the examples.
- Use parent storage if available as default storage media.
- Force reset on close for Android devices.
- Handle integrated USB hubs in mtp-probe.
- Devices, devices, devices...