### PR TITLE
tvheadend: add option to wait for network

### DIFF
--- a/addons/service/multimedia/tvheadend/changelog.txt
+++ b/addons/service/multimedia/tvheadend/changelog.txt
@@ -1,3 +1,6 @@
+4.3.10
+- add option to wait for network (when using network tuner)
+
 4.3.9
  - switch to dvbcsa on arm
 

--- a/addons/service/multimedia/tvheadend/package.mk
+++ b/addons/service/multimedia/tvheadend/package.mk
@@ -18,7 +18,7 @@
 
 PKG_NAME="tvheadend"
 PKG_VERSION="3.9.2427"
-PKG_REV="9"
+PKG_REV="10"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"

--- a/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
+++ b/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
@@ -35,6 +35,10 @@ TIMESHIFT_DIR="$ADDON_HOME/cache/timeshift"
 
 chmod a+x $ADDON_DIR/bin/*
 
+if [ "$WAIT_FOR_NET" == "true" ] ; then
+  cm-online $WAIT_FOR_NET_TIME
+fi
+
 if [ ! -f "$XMLTV_SETTINGS_FILE" ]; then
   mkdir -p $XMLTV_SETTINGS_DIR
   if [ -f $ADDON_DIR/xmltv-config ]; then

--- a/addons/service/multimedia/tvheadend/source/resources/language/English/strings.xml
+++ b/addons/service/multimedia/tvheadend/source/resources/language/English/strings.xml
@@ -14,5 +14,7 @@
 	<string id="1022">Wait for frontend initialization</string>
 	<string id="1023">Number of adapters to wait for</string>
 	<string id="1024">Preload capmt_ca.so library</string>
+	<string id="1025">Wait for network</string>
+	<string id="1026">time (s)</string>
 
 </strings>

--- a/addons/service/multimedia/tvheadend/source/resources/settings.xml
+++ b/addons/service/multimedia/tvheadend/source/resources/settings.xml
@@ -15,6 +15,8 @@
 		<setting type="sep" />
 		<setting id="WAIT_FOR_FEINIT" type="bool" label="1022" default="false" />
 		<setting id="NUM_ADAPTERS" type="slider" range="1,16" option="int" label="1023" default="1" enable="eq(-1,true)" />
+		<setting id="WAIT_FOR_NET" type="bool" label="1025" default="false" />
+		<setting id="WAIT_FOR_NET_TIME" type="slider" range="1,30" option="int" label="1026" default="1" enable="eq(-1,true)" />
 		<setting id="REMOVE_MODULES" type="text" label="1021" values="" default=""/>
 		<setting id="PRELOAD_CAPMT_CA" type="bool" label="1024" default="false" />
     </category>

--- a/addons/service/multimedia/tvheadend/source/settings-default.xml
+++ b/addons/service/multimedia/tvheadend/source/settings-default.xml
@@ -1,6 +1,8 @@
 <settings>
     <setting id="WAIT_FOR_FEINIT" value="false" />
     <setting id="NUM_ADAPTERS" value="1" />
+	<setting id="WAIT_FOR_NET" value="false" />
+    <setting id="WAIT_FOR_NET_TIME" value="1" />
     <setting id="XMLTV_LOCATION_FILE" value="" />
     <setting id="XMLTV_LOCATION_WEB" value="http://" />
     <setting id="XMLTV_TYPE" value="NONE" />


### PR DESCRIPTION
When using a network tuner like the HDHomerun, enable this option to
make sure the network is up before starting tvheadend. Especially with
native hdhomerun support, tvheadend will only check for the tuner on
startup.