### PR TITLE
tvheadend: bump to v3.9.2496

### DIFF
--- a/addons/service/multimedia/tvheadend/package.mk
+++ b/addons/service/multimedia/tvheadend/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="tvheadend"
-PKG_VERSION="3.9.2427"
-PKG_REV="10"
+PKG_VERSION="3.9.2496"
+PKG_REV="11"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"


### PR DESCRIPTION
Bumping Tvheadend to latest commit, tested with the tar.gz source from Tvheadend's Apt repository (of course compiled as an OpenELEC addon) on imx6 platform.

Reasons for bump:
* Fix [xml parser: skip UTF-8 BOM header](https://github.com/tvheadend/tvheadend/commit/3c0a2798251a4c40d1e89b6cf835f465438d4d1d), needed for xmltv.xml that's auto generated by my network tuner (VBox).
* AAC/LATM parser improvements, transcoding finally working with AAC-HEv2, commits [1](https://github.com/tvheadend/tvheadend/commit/cc1fbb02028c4e5baaf72deaa01b34748686e273) ,[2](https://github.com/tvheadend/tvheadend/commit/538e7acb569fd0bac1f9a1e29ff5398156ceccc3) and [3](https://github.com/tvheadend/tvheadend/commit/fafec1e053a22c50b2f2e3f1e8b407f708d9ad30).