### PR TITLE
support for .mpc and .ape audio formats by adding ffmpeg

### DIFF
--- a/addons/service/multimedia/mpd/changelog.txt
+++ b/addons/service/multimedia/mpd/changelog.txt
@@ -1,3 +1,6 @@
+4.3.3
+- support for .mpc and .ape files by adding dependency for ffmpeg
+
 4.3.2
 - rebuild
 

--- a/addons/service/multimedia/mpd/package.mk
+++ b/addons/service/multimedia/mpd/package.mk
@@ -19,13 +19,13 @@
 ################################################################################
 
 PKG_NAME="mpd"
-PKG_VERSION="0.18.11"
+PKG_VERSION="0.18.12"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mpd.wikia.com/wiki/Music_Player_Daemon_Wiki"
 PKG_URL="http://www.musicpd.org/download/${PKG_NAME}/${PKG_VERSION%.*}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain glib libmad libogg flac faad2 curl alsa-lib yajl libid3tag"
+PKG_DEPENDS_TARGET="toolchain glib ffmpeg libmad libogg flac faad2 curl alsa-lib yajl libid3tag"
 PKG_PRIORITY="optional"
 PKG_SECTION="service.multimedia"
 PKG_SHORTDESC="Flexible, powerful, server-side application for playing music"
@@ -56,7 +56,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-alsa \
              --disable-debug \
              --disable-documentation \
              --disable-ffado \
-             --disable-ffmpeg \
+             --enable-ffmpeg \
              --disable-fluidsynth \
              --disable-gme \
              --disable-httpd-output \


### PR DESCRIPTION
At the moment the mpd plugin can't play .ape (Monkey's_Audio) and .mpc (Musepack) files.

I tried to fix it, and build the plugin myself with ffmpeg enabled, it can play .mpc and .ape files now on my raspberry pi.

IMHO nice to add. 