### PR TITLE
Update jq to 1.5

### DIFF
--- a/addons/tools/jq/changelog.txt
+++ b/addons/tools/jq/changelog.txt
@@ -1,2 +1,5 @@
+6.0.1
+- Update jq to 1.5
+
 6.0.0
 - initial release

--- a/addons/tools/jq/package.mk
+++ b/addons/tools/jq/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="jq"
-PKG_VERSION="1.4"
-PKG_REV="0"
+PKG_VERSION="1.5"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="http://stedolan.github.io/jq/"
-PKG_URL="http://stedolan.github.io/jq/download/source/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="http://github.com/stedolan/jq/releases/download/$PKG_NAME-$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="tools"
@@ -38,7 +38,9 @@ PKG_AUTORECONF="yes"
 
 PKG_MAINTAINER="James White"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared \ 
+                           --enable-static \
+                           --disable-maintainer-mode"
 
 makeinstall_target() {
 	: # nop


### PR DESCRIPTION
Updated `jq` to 1.5 release, `PKG_REV` and `PKG_URL` updated accordingly. It appears the previous `PKG_URL` for `jq` 1.4 is now 404.

Additionally there is a new build flag `--disable-maintainer-mode` which means `configure` will use the pre-generated lexer and parser that comes with the source code. 

Using the pre-generated parser should speed up compile time and means `flex` and `bison` are not required, although they are part of the OpenELEC toolchain already so not having this flag will still lead to a successful compile. It is probably best if it is included, see note under "From source on Linux, OS X, Cygwin, and other POSIX-like operating systems"

https://stedolan.github.io/jq/download/