### PR TITLE
tvheadend: update to tvheadend-4.0.7-15

### DIFF
--- a/addons/service/multimedia/tvheadend/changelog.txt
+++ b/addons/service/multimedia/tvheadend/changelog.txt
@@ -1,3 +1,6 @@
+6.0.2
+- update to tvheadend-4.0.7-15
+
 6.0.1
 - update to tvheadend-4.0.3
 

--- a/addons/service/multimedia/tvheadend/package.mk
+++ b/addons/service/multimedia/tvheadend/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="tvheadend"
-PKG_VERSION="4.0.3"
-PKG_REV="1"
+PKG_VERSION="4.0.7-15"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvheadend.org"


### PR DESCRIPTION
updates Tvh to latest stable rls

source tarball need to be created and uploaded to oe sources
(or if you like http://mycvh.de/openelec/tvh/tvheadend-4.0.7-15.tar.gz)