### PR TITLE
fix missed version update

### DIFF
--- a/addons/service/multimedia/tvheadend/changelog.txt
+++ b/addons/service/multimedia/tvheadend/changelog.txt
@@ -1,4 +1,4 @@
-6.0.1
+6.0.2
 - update to tvheadend-4.0.7
 
 6.0.1


### PR DESCRIPTION
I think that should be version 6.0.2. I also cant download the update to 4.0.7 because package it not rebuild till now. Maybe the missing package version update is the reason for that.