### PR TITLE
[MPD] Add HTTP stream support

### DIFF
--- a/addons/service/multimedia/mpd/changelog.txt
+++ b/addons/service/multimedia/mpd/changelog.txt
@@ -1,5 +1,9 @@
+7.0.1
+- add HTTP streaming support generaly and MP3 streaming support by adding dependency for lame
+
 7.0.0
 - rebuild for OpenELEC-7.0
+
 6.0.0
 - rebuild for OE 6
 

--- a/addons/service/multimedia/mpd/package.mk
+++ b/addons/service/multimedia/mpd/package.mk
@@ -25,7 +25,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mpd.wikia.com/wiki/Music_Player_Daemon_Wiki"
 PKG_URL="http://www.musicpd.org/download/${PKG_NAME}/${PKG_VERSION%.*}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain glib ffmpeg libmad libogg flac faad2 curl alsa-lib yajl libid3tag"
+PKG_DEPENDS_TARGET="toolchain glib ffmpeg libmad libogg flac faad2 curl alsa-lib yajl libid3tag lame"
 PKG_PRIORITY="optional"
 PKG_SECTION="service.multimedia"
 PKG_SHORTDESC="Flexible, powerful, server-side application for playing music"
@@ -60,13 +60,13 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-alsa \
              --enable-ffmpeg \
              --disable-fluidsynth \
              --disable-gme \
-             --disable-httpd-output \
+             --enable-httpd-output \
              --enable-id3 \
              --disable-jack \
              --disable-lastfm \
              --disable-despotify \
              --disable-soundcloud \
-             --disable-lame-encoder \
+             --enable-lame-encoder \
              --disable-libwrap \
              --disable-lsr \
              --enable-mad \

--- a/addons/service/multimedia/mpd/package.mk
+++ b/addons/service/multimedia/mpd/package.mk
@@ -20,7 +20,7 @@
 
 PKG_NAME="mpd"
 PKG_VERSION="0.18.12"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://mpd.wikia.com/wiki/Music_Player_Daemon_Wiki"


### PR DESCRIPTION
Compile the MPD with HTTPD stream support and MP3 streams:
1. Add MP3 Encoder "lame" to "PKG_DEPENDS_TARGET"
2. --enable-lame-encoder at "PKG_CONFIGURE_OPTS_TARGET"
3. --enable-httpd-output at "PKG_CONFIGURE_OPTS_TARGET"