### PR TITLE
syncthing: update to 0.12.15

### DIFF
--- a/addons/service/system/syncthing/changelog.txt
+++ b/addons/service/system/syncthing/changelog.txt
@@ -1,2 +1,7 @@
+7.0.1
+- Upgrade to version 0.12.15
+- Skip default folder creation on new install
+- Enable setting of GUI address
+
 7.0.0
 - Initial release for version 0.12.12

--- a/addons/service/system/syncthing/package.mk
+++ b/addons/service/system/syncthing/package.mk
@@ -1,6 +1,6 @@
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2016 Anton Voyl (awiouy@gmail.com)
+#      Copyright (C) 2016 Anton Voyl (awiouy at gmail dot com)
 #
 #  OpenELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="syncthing"
-PKG_VERSION="0.12.12"
-PKG_REV="0"
+PKG_VERSION="0.12.15"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"
@@ -29,7 +29,7 @@ PKG_SECTION="service/system"
 PKG_SHORTDESC="Open Source Continuous File Synchronization"
 PKG_LONGDESC="Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet."
 PKG_DISCLAIMER="This is a community addon. Please don't ask for support in openelec forum or irc channel."
-PKG_MAINTAINER="Anton Voyl (awiouy@gmail.com)"
+PKG_MAINTAINER="Anton Voyl (awiouy at gmail dot com)"
 PKG_ADDON_REPOVERSION="7.0"
 
 PKG_IS_ADDON="yes"

--- a/addons/service/system/syncthing/source/bin/syncthing-service
+++ b/addons/service/system/syncthing/source/bin/syncthing-service
@@ -2,7 +2,7 @@
 
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2016 Anton Voyl (awiouy@gmail.com)
+#      Copyright (C) 2016 Anton Voyl (awiouy at gmail dot com)
 #
 #  OpenELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -23,9 +23,9 @@ oe_setup_addon service.system.syncthing
 
 chmod +x $ADDON_DIR/bin/*
 
-syncthing -home=$ADDON_HOME           \
-          -gui-address="0.0.0.0:8384" \
-          -logflags=0                 \
-          -no-browser                 \
-          -no-restart
+STNODEFAULTFOLDER="y" syncthing -home=$ADDON_HOME           \
+                                -gui-address="$gui_address" \
+                                -logflags=0                 \
+                                -no-browser                 \
+                                -no-restart
 

--- a/addons/service/system/syncthing/source/resources/language/English/strings.po
+++ b/addons/service/system/syncthing/source/resources/language/English/strings.po
@@ -1,0 +1,14 @@
+# Kodi Media Center language file
+# Addon Name: syncthing
+# Addon id: service.system.syncthing
+# Addon Provider: awiouy at gmail dot com
+msgid ""
+msgstr ""
+
+msgctxt "#30000"
+msgid "GUI Address"
+msgstr ""
+
+msgctxt "#30001"
+msgid "GUI Address after next restart"
+msgstr ""

--- a/addons/service/system/syncthing/source/resources/settings.xml
+++ b/addons/service/system/syncthing/source/resources/settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+   <category label="30000">
+      <setting id="gui_address" label="30001" type="text" default="0.0.0.0:8384" />
+   </category>
+</settings>
+

--- a/addons/service/system/syncthing/source/settings-default.xml
+++ b/addons/service/system/syncthing/source/settings-default.xml
@@ -1,0 +1,3 @@
+<settings>
+   <setting id="gui_address" value="0.0.0.0:8384" />
+</settings>


### PR DESCRIPTION
Hello,

Here are updates to the syncthing addon, mainly:
- enable setting of the GUI address,
- skip default folder creation on new install, and
- upgrade to version 0.12.15.

I expect that this should hold for a while, in particular since syncthing provides for automatic upgrades.

Thank you in advance, and regards,
@ 