### PR TITLE
[backport of #115] RPi.GPIO: update to RPi.GPIO-0.6.1

### DIFF
--- a/addons/tools/RPi.GPIO/changelog.txt
+++ b/addons/tools/RPi.GPIO/changelog.txt
@@ -1,3 +1,5 @@
+6.0.1
+- addon update to 0.6.1
 6.0.0
 - rebuild for OpenELEC-6.0
 4.3.2

--- a/addons/tools/RPi.GPIO/package.mk
+++ b/addons/tools/RPi.GPIO/package.mk
@@ -17,8 +17,8 @@
 ################################################################################
 
 PKG_NAME="RPi.GPIO"
-PKG_VERSION="0.5.11"
-PKG_REV="0"
+PKG_VERSION="0.6.1"
+PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="MIT"
 PKG_SITE="http://sourceforge.net/p/raspberry-gpio-python/"


### PR DESCRIPTION
backport of #115 