### PR TITLE
dispmanx_vnc: update to new upstream url, fix starting issue

### DIFF
--- a/addons/service/system/dispmanx_vnc/changelog.txt
+++ b/addons/service/system/dispmanx_vnc/changelog.txt
@@ -1,3 +1,6 @@
+7.0.1
+- update to use patrikolausson/dispmanx_vnc
+- fix issue where vnc server would start to quickly resulting in a black screen
 7.0.0
 - rebuild for OpenELEC-7.0
 6.0.0

--- a/addons/service/system/dispmanx_vnc/package.mk
+++ b/addons/service/system/dispmanx_vnc/package.mk
@@ -20,13 +20,13 @@
 
 PKG_NAME="dispmanx_vnc"
 PKG_ADDON_NAME="Raspberry Pi VNC"
-PKG_VERSION="a061e0a"
-PKG_REV="0"
+PKG_VERSION="78e6673"
+PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="OSS"
-PKG_SITE="https://github.com/hanzelpeter/dispmanx_vnc"
+PKG_SITE="https://github.com/patrikolausson/dispmanx_vnc"
 PKG_URL="$DISTRO_SRC/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain libvncserver bcm2835-driver"
+PKG_DEPENDS_TARGET="toolchain libvncserver bcm2835-driver libconfig"
 PKG_PRIORITY="optional"
 PKG_SECTION="service/system"
 PKG_SHORTDESC="VNC Server for Raspberry PI using dispmanx"
@@ -43,31 +43,8 @@ PKG_AUTORECONF="no"
 
 PKG_MAINTAINER="Lukas Rusak (lrusak at irc.freenode.net)"
 
-make_target() {  
-  $CC $CFLAGS main.c -o dispmanx_vncserver -DHAVE_LIBBCM_HOST \
-                                           -DUSE_EXTERNAL_LIBBCM_HOST \
-                                           -DUSE_VCHIQ_ARM \
-                                           $LDFLAGS \
-                                           -I$SYSROOT_PREFIX/include \
-                                           -I$SYSROOT_PREFIX/usr/include \
-                                           -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads \
-                                           -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host \
-                                           -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux \
-                                           -L$SYSROOT_PREFIX/usr/lib \
-                                           -L$SYSROOT_PREFIX/lib \
-                                           -lGLESv2 \
-                                           -lEGL \
-                                           -lopenmaxil \
-                                           -lbcm_host \
-                                           -lvcos \
-                                           -lvchiq_arm \
-                                           -lpthread \
-                                           -lrt \
-                                           -lz \
-                                           -lssl -lcrypto \
-                                           -lresolv \
-                                           -lvncserver \
-                                           -ljpeg -lpng16
+pre_make_target() {
+  export SYSROOT_PREFIX
 }
 
 makeinstall_target() {
@@ -75,6 +52,9 @@ makeinstall_target() {
 }
 
 addon() {
-  mkdir -p $ROOT/$ADDON_BUILD/$PKG_ADDON_ID/bin
-    cp -p $ROOT/$PKG_BUILD/dispmanx_vncserver $ROOT/$ADDON_BUILD/$PKG_ADDON_ID/bin
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
+    cp -p $PKG_BUILD/dispmanx_vncserver $ADDON_BUILD/$PKG_ADDON_ID/bin
+
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/config
+    cp $PKG_DIR/source/config/dispmanx_vncserver.conf $ADDON_BUILD/$PKG_ADDON_ID/config/
 }

--- a/addons/service/system/dispmanx_vnc/patches/dispmanx_vnc-0001_fix-cross-compile.patch
+++ b/addons/service/system/dispmanx_vnc/patches/dispmanx_vnc-0001_fix-cross-compile.patch
@@ -1,0 +1,20 @@
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2016-01-22 20:52:21.000000000 +0100
++++ b/Makefile	2016-01-22 21:29:34.601124600 +0100
+@@ -1,9 +1,11 @@
+-CXX = g++
+-CXXFLAGS = -Wall -std=c++11 -O3 -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM
++CXX ?= g++
++CXXFLAGS += -Wall -std=c++11 -O3 -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM
+ 
+-INCLUDES = -I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
+-LIB_PATHS = -L/opt/vc/lib/
+-LIBS = -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lvncserver -lconfig++
++SYSROOT_PREFIX ?=
++
++INCLUDES = -I$(SYSROOT_PREFIX)/usr/include/ -I$(SYSROOT_PREFIX)/usr/include/interface/vcos/pthreads -I$(SYSROOT_PREFIX)/usr/include/interface/vmcs_host/linux
++LIB_PATHS = -L$(SYSROOT_PREFIX)/usr/lib/
++LIBS = -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lconfig++ -lz -lssl -lcrypto -lresolv -lvncserver -ljpeg -lpng16
+ 
+ SOURCES = main.cpp \
+ 		UFile.cpp \

--- a/addons/service/system/dispmanx_vnc/source/bin/dispmanx_vncserver-config
+++ b/addons/service/system/dispmanx_vnc/source/bin/dispmanx_vncserver-config
@@ -1,0 +1,26 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+. /etc/profile
+
+oe_setup_addon service.system.dispmanx_vnc
+
+if [ ! -f "$ADDON_HOME/dispmanx_vncserver.conf" ]; then
+  cp $ADDON_DIR/config/dispmanx_vncserver.conf $ADDON_HOME/
+fi

--- a/addons/service/system/dispmanx_vnc/source/config/dispmanx_vncserver.conf
+++ b/addons/service/system/dispmanx_vnc/source/config/dispmanx_vncserver.conf
@@ -1,0 +1,9 @@
+relative = false;
+port = 5900;
+screen = 0;
+unsafe = false;
+fullscreen = true;
+multi-threaded = false;
+password = "";
+frame-rate = 15;
+downscale = false;

--- a/addons/service/system/dispmanx_vnc/source/system.d/service.system.dispmanx_vnc.service
+++ b/addons/service/system/dispmanx_vnc/source/system.d/service.system.dispmanx_vnc.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=dispmanx_vnc
-After=graphical.target
+After=kodi.service
 
 [Service]
-ExecStart=/storage/.kodi/addons/service.system.dispmanx_vnc/bin/dispmanx_vncserver
+ExecStartPre=-/storage/.kodi/addons/service.system.dispmanx_vnc/bin/dispmanx_vncserver-config
+ExecStart=/bin/sh -c "/bin/sleep 10 && /storage/.kodi/addons/service.system.dispmanx_vnc/bin/dispmanx_vncserver --config-file=/storage/.kodi/userdata/addon_data/service.system.dispmanx_vnc/dispmanx_vncserver.conf"
 TimeoutStopSec=1
 Restart=always
 RestartSec=2

--- a/lib/libconfig/package.mk
+++ b/lib/libconfig/package.mk
@@ -1,0 +1,38 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="libconfig"
+PKG_VERSION="1.5"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="LGPL"
+PKG_SITE="http://hyperrealm.com/libconfig/libconfig.html"
+PKG_URL="http://www.hyperrealm.com/libconfig/$PKG_NAME-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="lib"
+PKG_SHORTDESC="C/C++ Configuration File Library"
+PKG_LONGDESC="C/C++ Configuration File Library"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+                           --disable-shared \
+                           --disable-examples \
+                           --with-sysroot=$SYSROOT_PREFIX"

--- a/lib/libconfig/patches/libconfig-0001_fix-include.patch
+++ b/lib/libconfig/patches/libconfig-0001_fix-include.patch
@@ -1,0 +1,12 @@
+diff -Naur a/tests/Makefile.am b/tests/Makefile.am
+--- a/tests/Makefile.am	2014-03-04 03:04:17.000000000 +0100
++++ b/tests/Makefile.am	2016-01-22 21:22:38.742833399 +0100
+@@ -3,7 +3,7 @@
+ 
+ libconfig_tests_SOURCES = tests.c
+ 
+-libconfig_tests_CPPFLAGS = -I$(top_srcdir)/tinytest -I../lib
++libconfig_tests_CPPFLAGS = -I$(top_srcdir)/tinytest -I$(top_srcdir)/lib
+ 
+ libconfig_tests_LDADD = -L$(top_builddir)/tinytest -ltinytest \
+ 	-L$(top_builddir)/lib/.libs -lconfig

--- a/tools/mkpkg_dispmanx_vnc
+++ b/tools/mkpkg_dispmanx_vnc
@@ -21,7 +21,7 @@
 
 echo "getting sources..."
   if [ ! -d dispmanx_vnc.git ]; then
-    git clone https://github.com/DavidVentura/dispmanx_vnc.git dispmanx_vnc.git
+    git clone https://github.com/patrikolausson/dispmanx_vnc.git dispmanx_vnc.git
   fi
 
   cd dispmanx_vnc.git


### PR DESCRIPTION
This makes it actually useable :)

This adds a config file that is available at
`/storage/.kodi/userdata/addon_data/service.system.dispmanx_vnc/dispmanx_vncserver.conf`
or via the userdata SMB share
